### PR TITLE
Fix for context menu position on Firefox

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -206,7 +206,7 @@ var v = new Vue({
      */
     positionContextMenu: function (event) {
       // Get current key and it's position'
-      var key = event.srcElement;
+      var key = event.srcElement || event.target;
       var position = this.cumulativeOffset(key);
 
       Vue.nextTick(function () {


### PR DESCRIPTION
Just needed a missing `event.target`. Could probably remove both instances of `event.srcElement` but leaving in for now