### PR TITLE
format the json in the configuration box for easier sharing of layers

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -236,8 +236,9 @@ var v = new Vue({
             keymap.push(layer);
         }
 
-        keyboard['keymap'] = keymap
-        return JSON.stringify(keyboard);
+        keyboard['keymap'] = keymap;
+        return JSON.stringify(keyboard).replace(/,\[\[/g, ',\n\n[[');
+
     },
 
     saveLayout: function() {


### PR DESCRIPTION
adds two newlines after each layer so in case you want to copy paste a
single layer instead of the entire layout over or shift em around it’s easier